### PR TITLE
fix: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   },
   "dependencies": {
     "jssha": "3.2.0"
+  },
+  "homepage": "https://github.com/tonwhales/ton-crypto-primitives#readme",
+  "bugs": {
+    "url": "https://github.com/tonwhales/ton-crypto-primitives/issues"
   }
 }


### PR DESCRIPTION
Adds standard npm support metadata to `package.json`:

- `homepage` points to the repository README
- `bugs.url` points to the GitHub issue tracker

Current `npm view ton-crypto-primitives@2.0.0 ... homepage bugs` omits those fields even though the public repository and issue tracker exist.

Verification:

```sh
node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ton crypto primitives package json valid')"
npm pack --dry-run --json --ignore-scripts
```

Metadata-only change; no runtime behavior changes.